### PR TITLE
Fix #subscribe double click

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, Layout, Menu, Popover } from 'antd';
 import styled from 'styled-components';
-import { Link } from 'react-static';
+import { Link, scrollTo } from 'react-static';
 import { size } from '../breakpoints';
 import logoImg from '@images/logo_light.svg';
 
@@ -123,6 +123,13 @@ class Navbar extends React.Component {
         current: path
       });
     }
+    const resolvedHash = path.substring(path.indexOf('#') + 1);
+    if (path === location.pathname + location.hash) {
+      const element = document.getElementById(resolvedHash);
+      if (element !== null) {
+        scrollTo(element);
+      }
+    }
   }
 
   renderMenuMarkup(breakpoint: string): JSX.Element {
@@ -159,7 +166,7 @@ class Navbar extends React.Component {
             FAQs
           </Link>
         </Menu.Item>
-        <Menu.Item key="/subscribe">
+        <Menu.Item key="/#subscribe">
           <Link
             to="/#subscribe"
             style={{ color: 'inherit', textDecoration: 'none' }}


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/MARKETProtocol/meta/blob/master/CONTRIBUTING.md
-->

##### Description
Fixes the issue described in #31.
The only way I see to fix this is to force a scroll in the click handler, because the routing library does not do anything when the URL stays the same.

I tried to make this force-scroll as minimal as possible. It only executes when a Link is clicked that is already active, also I have imported the same scroll logic from the router for consistency.

Regarding the scroll not working when going from `/team` --> `/#subscribe`, it is because the scroll happens during the loading screen of the subscribe page.
However, when running the app using `make build && npm run serve`, the home page gets preloaded and there is no loading screen, therefore the problem does not exist.

So I have done nothing to address this, it works in production.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
UI, UX

##### Testing
Test that the scroll works by clicking subscribe, scrolling up again and clicking it again.

##### Refers/Fixes
Fixes #31